### PR TITLE
added ALM to the list of typescript IDEs

### DIFF
--- a/src/documents/directory/tools.html.md
+++ b/src/documents/directory/tools.html.md
@@ -29,6 +29,7 @@ title: 'Tools & Editors'
 
 ## IDE with TypeScript Support
 
+* [Alm](http://alm.tools/)
 * [TypeScript Playground](http://www.typescriptlang.org/Playground/)
 * [Visual Studio](http://www.microsoft.com/visualstudio/eng)
 * [WebStorm](http://www.jetbrains.com/webstorm/)


### PR DESCRIPTION
I added [alm](http://alm.tools/) to the list of IDEs that support typescript.
It's a free open source project hosted here: https://github.com/alm-tools/alm