### PR TITLE
docs: fix site.github link

### DIFF
--- a/src/documents/directory/learn.html.md
+++ b/src/documents/directory/learn.html.md
@@ -7,7 +7,7 @@ title: 'Learn TypeScript'
 
 * [Official website](http://www.typescriptlang.org)
 * [Codeplex project site](http://typescript.codeplex.com)
-* [DefinitelyTyped](<%-@site.github%>)
+* [DefinitelyTyped](<%- @site.github %>)
 
 
 ## Language


### PR DESCRIPTION
This appears to break the Markdown preview, but the placehold appears to not be replace right now.
I didn't do a local build, so this is just a guess right now based off the other instance that are working