### PR TITLE
Fix getter/setter section contains misinformation

### DIFF
--- a/src/documents/guides/best-practices.html.md.eco
+++ b/src/documents/guides/best-practices.html.md.eco
@@ -52,17 +52,6 @@ var foo = new Date();
 foo.newMember = 123; // okay
 ```
 
-### Getter / Setter
-Instead of :
-```typescript
-declare function duration(value?: number): any;
-```
-better to do:
-```typescript
-declare function duration(): number;
-declare function duration(value: number): void;
-```
-
 ### Fluent
 Pretty self explanatory:
 ```typescript


### PR DESCRIPTION
Removes the "Getter / Setter" section from the best practices guide because it violates TypeScript standards and best practices: The [TypeScript guide on Do's and Don'ts](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#function-overloads) explicitely states that optional parameters are to be preferred.