### PR TITLE
Add information about publishing schedule

### DIFF
--- a/src/documents/guides/contributing.html.md.eco
+++ b/src/documents/guides/contributing.html.md.eco
@@ -68,6 +68,10 @@ See the [best practices](/guides/best-practices.html) for more info on how to st
 ## Private APIs
 We do not support exposing *undocumented* internal implementation details of libraries in `.d.ts` files. We follow this more strictly for *popular* libraries with good documentation e.g. jquery, angular, node etc.
 
+### Publishing
+
+After your pull request has been merged, your NPM package should be updated within a few hours. If it's been more than 24 hours, ping @RyanCavanaugh and @andy-ms on the PR to investigate.
+
 ### Note
 
 Keep in mind the repos is a community project with a wide range on quality in contributions and moderation; so there may be the occasional rule violation or historical artifact.

--- a/src/documents/guides/contributing.html.md.eco
+++ b/src/documents/guides/contributing.html.md.eco
@@ -70,7 +70,7 @@ We do not support exposing *undocumented* internal implementation details of lib
 
 ### Publishing
 
-After your pull request has been merged, your NPM package should be updated within a few hours. If it's been more than 24 hours, ping @RyanCavanaugh and @andy-ms on the PR to investigate.
+After your pull request has been merged, your NPM package should be updated within a few hours. If it's been more than 24 hours, ping @RyanCavanaugh and @sandersn on the PR to investigate.
 
 ### Note
 


### PR DESCRIPTION
This wasn't obvious to me when I was looking on the site for the publishing schedule. I wasn't sure if it should go somewhere else instead? I saw it on the [README](https://github.com/DefinitelyTyped/DefinitelyTyped#my-pr-is-merged-when-will-the-types-npm-package-be-updated) too, but I expected the site would have the most information about this.