### PR TITLE
Update wiki link for typescript

### DIFF
--- a/src/documents/guides/contributing.html.md.eco
+++ b/src/documents/guides/contributing.html.md.eco
@@ -33,7 +33,7 @@ If the version of the library is known then add it as a semver to the label.
 
 ### Namespacing
 
-* Be careful to use a module to avoid conflicts to your internal interfaces and the interfaces from another typings. See [best practices](/guides/best-practices.html) and [the TypeScript wiki](https://typescript.codeplex.com/wikipage?title=Writing%20Definition%20%28.d.ts%29%20Files) for some tips.
+* Be careful to use a module to avoid conflicts to your internal interfaces and the interfaces from another typings. See [best practices](/guides/best-practices.html) and [the TypeScript wiki](https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/declaration%20files/Introduction.md) for some tips.
 
 > The [`jQuery.bbq` typing](<%-@site.github%>/blob/master/types/jquery.bbq/index.d.ts) has the interfaces in a module named `JQueryBbq`
 


### PR DESCRIPTION
Typescript wiki [has moved from codeplex to github](https://blogs.msdn.microsoft.com/typescript/2014/07/21/new-compiler-and-moving-to-github/).
This pr fixes one of the links in contributing guide
