### PR TITLE
Fixed wiki link

### DIFF
--- a/src/documents/guides/creating.html.md.eco
+++ b/src/documents/guides/creating.html.md.eco
@@ -3,4 +3,4 @@ layout: 'guide'
 title: 'Creating a definition file'
 ---
 
-The official TypeScript website has a [guide](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) to teach you how to write a high-quality TypeScript Declaration File. The official TypeScript wiki on codeplex.com also has a [great article](https://typescript.codeplex.com/wikipage?title=Writing%20Definition%20%28.d.ts%29%20Files) on how to write a good type declaration file. It is recommended you read those as it covers some important choices.
+The official TypeScript website has a [guide](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) to teach you how to write a high-quality TypeScript Declaration File. The official TypeScript wiki on codeplex.com also has a [great article](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) on how to write a good type declaration file. It is recommended you read those as it covers some important choices.


### PR DESCRIPTION
The past link to the Typescript wiki is not longer working, the typescript handbook seems to be where it ended up.