### PR TITLE
Replace dead Codeplex link with Wayback Machine link

### DIFF
--- a/src/documents/guides/best-practices.html.md.eco
+++ b/src/documents/guides/best-practices.html.md.eco
@@ -116,4 +116,4 @@ var b = foo({ x: 5 }); // b: Parent
 var y: any;
 var c = foo(y); // c: any
 ```
-[Related issue on Codeplex(vote)](https://typescript.codeplex.com/workitem/2442)
+[Related issue on Codeplex](https://web.archive.org/web/20170624122025/https://typescript.codeplex.com/workitem/2442)


### PR DESCRIPTION
The [Best practices](https://definitelytyped.org/guides/best-practices.html) page contains a link to a Codeplex issue. This replaces the link with the equivalent page on the Wayback Machine.