### PR TITLE
Fix minor grammatical error at top of every page.

### DIFF
--- a/docpad.js
+++ b/docpad.js
@@ -13,8 +13,8 @@ var docpadConfig = {
 			},
 			oldUrls: [],
 			title: 'DefinitelyTyped',
-			description: 'The repository for high quality TypeScript type definitions',
-			tagline: 'The repository for high quality TypeScript type definitions',
+			description: 'The repository for high-quality TypeScript type definitions',
+			tagline: 'The repository for high-quality TypeScript type definitions',
 			keywords: 'typescript, type, definition, declaration, repository, typing',
 			styles: [
 				'/styles/semantic.min.css',


### PR DESCRIPTION
"High-quality" is the way to use a compound adjective, which is how the phrase is being used in "The repository for high quality TypeScript type definitions".  

More information: https://ell.stackexchange.com/questions/133374/high-quality-or-high-quality/

This is an extremely minor error, but since it's in the header, is probably worth correcting.